### PR TITLE
Fix/channel/api

### DIFF
--- a/docs/API_references/backend_workspace_apis.md
+++ b/docs/API_references/backend_workspace_apis.md
@@ -3,77 +3,99 @@
 ---
 
 ## 워크스페이스 API
-| Method | URI                      | Description          | Parameter | Request Body       | etc    |
-|--------|--------------------------|----------------------|-----------|--------------------|--------|
-| GET    | /workspace               | 사용자 1명의 워크스페이스 목록 조회 | userId    | -                  | -      |
-| GET    | /workspace/{id}          | 워크스페이스 1개의 정보 조회     | -         | -                  | -      |
-| GET    | /workspace/{id}/members  | 워크스페이스 1개의 멤버 조회     | -         | -                  | paging |
-| GET    | /workspace/{id}/channels | 워크스페이스 1개의 채널 조회     | -         | -                  | paging |
-| POST   | /workspace               | 워크스페이스 생성            | -         | WorkspaceImportDTO | -      |
-| PUT    | /workspace/{id}          | 워크스페이스 수정            | -         | WorkspaceImportDTO | -      |
-| DELETE | /workspace/{id}          | 워크스페이스 삭제            | -         | -                  | -      |
+| Method | URI                      | Description          | Parameter  | Request Body       | Response Body      | etc    |
+|--------|--------------------------|----------------------|------------|--------------------|--------------------|--------|
+| GET    | /workspace               | 사용자 1명의 워크스페이스 목록 조회 | userId     | -                  | 워크스페이스 목록          | paging |
+| GET    | /workspace/{id}          | 워크스페이스 1개의 정보 조회     | -          | -                  | 워크스페이스 1개 정보       | -      |
+| GET    | /workspace/{id}/members  | 워크스페이스 1개의 멤버 조회     | -          | -                  | 멤버 목록              | paging |
+| GET    | /workspace/{id}/channels | 워크스페이스 1개의 채널 조회     | -          | -                  | 채널 목록              | paging |
+| POST   | /workspace               | 워크스페이스 생성            | -          | WorkspaceCreateDTO | 워크스페이스, 채널 각 1개 정보 | -      |
+| PUT    | /workspace/{id}          | 워크스페이스 수정            | -          | WorkspaceEditDTO   | -                  | -      |
+| DELETE | /workspace/{id}          | 워크스페이스 삭제            | -          | -                  | -                  | -      |
 
 ## 워크스페이스-멤버 API
-| Method | URI               | Description    | Parameter | Request Body        | etc |
-|--------|-------------------|----------------|-----------|---------------------|-----|
-| POST   | /workspace/member | 워크스페이스에 멤버 추가  | -         | AccountWorkspaceDTO | -   |
-| DELETE | /workspace/member | 워크스페이스에서 멤버 삭제 | -         | AccountWorkspaceDTO | -   |
+| Method | URI               | Description    | Parameter | Request Body        | Response Body | etc |
+|--------|-------------------|----------------|-----------|---------------------|---------------|-----|
+| POST   | /workspace/member | 워크스페이스에 멤버 추가  | -         | AccountWorkspaceDTO | -             | -   |
+| DELETE | /workspace/member | 워크스페이스에서 멤버 삭제 | -         | AccountWorkspaceDTO | -             | -   |
 
 ## 채널 API
-| Method | URI                   | Description  | Parameter | Request Body     | etc    |
-|--------|-----------------------|--------------|-----------|------------------|--------|
-| GET    | /channel/{id}         | 채널 1개의 정보 조회 | -         | -                | -      |
-| GET    | /channel/{id}/members | 채널 1개의 멤버 조회 | -         | -                | paging |
-| POST   | /channel              | 채널 생성        | -         | ChannelImportDTO | -      |
-| PUT    | /channel/{id}         | 채널 수정        | -         | ChannelImportDTO | -      |
-| DELETE | /channel/{id}         | 채널 삭제        | -         | ChannelImportDTO | -      |
+| Method | URI                   | Description  | Parameter | Request Body     | Response Body | etc    |
+|--------|-----------------------|--------------|-----------|------------------|---------------|--------|
+| GET    | /channel/{id}         | 채널 1개의 정보 조회 | -         | -                | 채널 1개 정보      | -      |
+| GET    | /channel/{id}/members | 채널 1개의 멤버 조회 | -         | -                | 멤버 목록         | paging |
+| POST   | /channel              | 채널 생성        | -         | ChannelCreateDTO | 채널 1개 정보      | -      |
+| PUT    | /channel/{id}         | 채널 수정        | -         | ChannelEditDTO   | -             | -      |
+| DELETE | /channel/{id}         | 채널 삭제        | -         | -                | -             | -      |
 
 ## 채널-멤버 API
-| Method | URI             | Description     | Parameter | Request Body      | etc |
-|--------|-----------------|-----------------|-----------|-------------------|-----|
-| POST   | /channel/member | 채널에 멤버 추가       | -         | AccountChannelDto | -   |
-| PUT    | /channel/member | 채널에 대한 멤버 정보 수정 | -         | AccountChannelDto | -   |
-| DELETE | /channel/member | 채널에서 멤버 삭제      | -         | AccountChannelDto | -   |
+| Method | URI             | Description     | Parameter | Request Body      | Response Body | etc |
+|--------|-----------------|-----------------|-----------|-------------------|---------------|-----|
+| POST   | /channel/member | 채널에 멤버 추가       | -         | AccountChannelDto | -             | -   |
+| PUT    | /channel/member | 채널에 대한 멤버 정보 수정 | -         | AccountChannelDto | -             | -   |
+| DELETE | /channel/member | 채널에서 멤버 삭제      | -         | AccountChannelDto | -             | -   |
 
 
-- WorkspaceImportDTO 예시
+- WorkspaceCreateDTO 예시
     ```
     {
-        "name": "workspace1",
-        "description": "my first workspace",
-        "settings": 12,
-        "status": 34,
+        "creatorId": 1,
+        "workspaceName": "workspaceMake",
+        "workspaceDescription": "make new workspace",
+        "channelName": "channelMake",
+        "channelTopic": "test",
+        "channelDescription": "make new channel"
     }
     ```
-    - `POST /workspace`에서는 `name` 생략 불가능, 이외 속성은 생략 가능
-    - `PUT /workspace/{id}`에서는 모든 속성 생략 가능
+    - `workspaceDescription`, `channelDescription` 생략 가능, 이외 생략 불가
+
+
+- WorkspaceEditDTO 예시
+  ```
+  {
+    "name": "workspaceEdited",
+    "description": "editing workspace",
+    "settings": 123,
+    "status": 11
+  }
+  ```
+  - 모든 속성 생략 가능 (모두 생략 시 `PUT /workspace/{id}` 통한 변경사항 없음)
 
 
 - AccountWorkspaceDTO 예시
-    ```
-    {
-        "accountId": 123,
-        "workspaceId": 456
-    }
-    ```
-    - 모든 속성이 항상 필요함
-
-
-- ChannelImportDTO 예시
   ```
   {
-      "workspaceId": 6,
-      "creatorId": 3,
-      "name": "new channel",
-      "topic": "channel test",
-      "description": "asdf",
-      "settings": 123,
-      "status": 45
+    "accountId": 123,
+    "workspaceId": 456
   }
   ```
-  - `POST /channel`에서 `workspaceId`, `creatorId`, `name` 필수
-  - `PUT /workspace/{id}`에서 모든 속성 생략 가능
+  - 모든 속성 생략 불가
 
+
+- ChannelCreateDTO 예시
+  ```
+  {
+    "workspaceId": 6,
+    "creatorId": 3,
+    "name": "new channel",
+    "topic": "channel test",
+    "description": "asdf"
+  }
+  ```
+  - `topic`, `description` 생략 가능, 이외 생략 불가
+
+
+- ChannelEditDTO 예시
+  ```
+  {
+    "name": "edit channel",
+    "topic": "test",
+    "description": "qwer",
+    "settings": 12,
+    "status": 3
+  }
+  ```
+  - 모든 속성 생략 가능 (모두 생략 시 `PUT /channel/{id}` 통한 변경사항 없음)
 
 - AccountChannelDto 예시
   ```

--- a/src/backend/workspace/README.md
+++ b/src/backend/workspace/README.md
@@ -33,5 +33,5 @@
   - 중복된 record 처리에 대한 로직 필요
 - DTO에서 생략 불가능한 field가 있는데 생략된 정보가 있을 경우의 에러처리
 - DB 관련 에러들을 BusinessError로 wrapping 해야 함
-- 현재 `GET /channel/{id}/members` API가 멤버 목록을 정상 반환하지 않음 ([관련 이슈](https://github.com/njsh4261/SGS_Last_Punch/issues/91))
+~~- 현재 `GET /channel/{id}/members` API가 멤버 목록을 정상 반환하지 않음 ([관련 이슈](https://github.com/njsh4261/SGS_Last_Punch/issues/91))~~ 220120 수정
 - 이외 내용은 코드 주석 내용 참조

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/controller/AccountChannelController.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/controller/AccountChannelController.java
@@ -17,7 +17,7 @@ public class AccountChannelController{
     public AccountChannelController(AccountChannelService accountChannelService){
         this.accountChannelService = accountChannelService;
     }
-
+    
     @PostMapping
     public ResponseEntity<Object> add(@RequestBody AccountChannel.Dto accountChannelDto){
         accountChannelService.add(accountChannelDto);

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/controller/ChannelController.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/controller/ChannelController.java
@@ -29,14 +29,13 @@ public class ChannelController{
     
     @GetMapping("/{id}/members")
     public ResponseEntity<Object> getMembers(
-            @PathVariable("id") Long id, @PageableDefault(page = PAGESIZE) Pageable pageable){
+            @PathVariable("id") Long id, @PageableDefault(size = PAGESIZE) Pageable pageable){
         return Response.ok(ServerCode.WORKSPACE, channelService.getMembers(id, pageable));
     }
     
     @PostMapping
     public ResponseEntity<Object> create(@RequestBody CreateDto channelCreateDto){
-        channelService.create(channelCreateDto);
-        return Response.ok(ServerCode.WORKSPACE);
+        return Response.ok(ServerCode.WORKSPACE, channelService.create(channelCreateDto));
     }
     
     @PutMapping("/{id}")

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/controller/ChannelController.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/controller/ChannelController.java
@@ -3,6 +3,7 @@ package lastpunch.workspace.controller;
 import lastpunch.workspace.common.Response;
 import lastpunch.workspace.common.ServerCode;
 import lastpunch.workspace.entity.Channel;
+import lastpunch.workspace.entity.Channel.CreateDto;
 import lastpunch.workspace.service.ChannelService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -33,15 +34,15 @@ public class ChannelController{
     }
     
     @PostMapping
-    public ResponseEntity<Object> create(@RequestBody Channel.ImportDto channelImportDto){
-        channelService.create(channelImportDto);
+    public ResponseEntity<Object> create(@RequestBody CreateDto channelCreateDto){
+        channelService.create(channelCreateDto);
         return Response.ok(ServerCode.WORKSPACE);
     }
     
     @PutMapping("/{id}")
     public ResponseEntity<Object> edit(
-            @PathVariable("id") Long id, @RequestBody Channel.ImportDto channelImportDto){
-        channelService.edit(id, channelImportDto);
+            @PathVariable("id") Long id, @RequestBody Channel.EditDto editDto){
+        channelService.edit(id, editDto);
         return Response.ok(ServerCode.WORKSPACE);
     }
     

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/controller/WorkspaceController.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/controller/WorkspaceController.java
@@ -48,8 +48,7 @@ public class WorkspaceController{
 
     @PostMapping
     public ResponseEntity<Object> create(@RequestBody Workspace.CreateDto createDto){
-        workspaceService.create(createDto);
-        return Response.ok(ServerCode.WORKSPACE);
+        return Response.ok(ServerCode.WORKSPACE, workspaceService.create(createDto));
     }
 
     @PutMapping("/{id}")

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/controller/WorkspaceController.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/controller/WorkspaceController.java
@@ -1,5 +1,6 @@
 package lastpunch.workspace.controller;
 
+import lastpunch.workspace.entity.Channel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -46,14 +47,14 @@ public class WorkspaceController{
     }
 
     @PostMapping
-    public ResponseEntity<Object> create(@RequestBody Workspace.ImportDto workspaceDto){
-        workspaceService.create(workspaceDto);
+    public ResponseEntity<Object> create(@RequestBody Workspace.CreateDto createDto){
+        workspaceService.create(createDto);
         return Response.ok(ServerCode.WORKSPACE);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<Object> edit(
-            @RequestBody Workspace.ImportDto workspaceDto, @PathVariable("id") Long id){
+            @RequestBody Workspace.EditDto workspaceDto, @PathVariable("id") Long id){
         workspaceService.edit(workspaceDto, id);
         return Response.ok(ServerCode.WORKSPACE);
     }

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Channel.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Channel.java
@@ -69,7 +69,7 @@ public class Channel{
     List<AccountChannel> accounts;
     
     @Getter
-    public class CreateDto {
+    public static class CreateDto{
         private Long workspaceId;
         private Long creatorId;
         private String name;
@@ -91,7 +91,7 @@ public class Channel{
         }
     }
     
-    public class EditDto{
+    public static class EditDto{
         private String name;
         private String topic;
         private String description;
@@ -109,7 +109,7 @@ public class Channel{
     }
     
     @Getter
-    public class ExportDto{
+    public static class ExportDto{
         private Long id;
         private Workspace.ExportDto workspace;
         private Account.ExportDto creator;

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Channel.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Channel.java
@@ -69,26 +69,50 @@ public class Channel{
     List<AccountChannel> accounts;
     
     @Getter
-    public static class ImportDto{
+    public class CreateDto {
         private Long workspaceId;
         private Long creatorId;
         private String name;
         private String topic;
         private String description;
+
+        public Channel toEntity(Workspace workspace, Account account){
+            return Channel.builder()
+                .workspace(workspace)
+                .account(account)
+                .name(name)
+                .topic(topic)
+                .description(description)
+                .settings(0)
+                .status(0)
+                .createdt(LocalDateTime.now())
+                .modifydt(LocalDateTime.now())
+                .build();
+        }
+    }
+    
+    public class EditDto{
+        private String name;
+        private String topic;
+        private String description;
         private Integer settings;
         private Integer status;
-
-        public boolean isEmpty(){
-            return (workspaceId == null) && (creatorId == null) && (name == null) && (topic == null)
-                    && (description == null) && (settings == null) && (status == null);
+        
+        public Channel toEntity(Channel channel){
+            channel.setName(name);
+            channel.setTopic(topic);
+            channel.setDescription(description);
+            channel.setSettings(settings);
+            channel.setStatus(status);
+            return channel;
         }
     }
     
     @Getter
-    public static class ExportDto{
+    public class ExportDto{
         private Long id;
-        private Long workspaceId; // TODO: 필요에 따라 WorkspaceExportDto로 변경
-        private Account.ExportDto creator; // TODO: 필요에 따라 더 적은 정보만을 전달
+        private Workspace.ExportDto workspace;
+        private Account.ExportDto creator;
         private String name;
         private String topic;
         private String description;
@@ -102,7 +126,7 @@ public class Channel{
                          String description, Integer settings, Integer status,
                          LocalDateTime createDt, LocalDateTime modifyDt) {
             this.id = id;
-            this.workspaceId = workspace.getId();
+            this.workspace = workspace.export();
             this.creator = account.export();
             this.name = name;
             this.topic = topic;

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Role.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Role.java
@@ -1,6 +1,6 @@
 package lastpunch.workspace.entity;
 
-import java.util.Set;
+import java.util.List;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -29,5 +29,5 @@ public class Role{
     private String name;
     
     @OneToMany(mappedBy = "role", orphanRemoval = true)
-    Set<AccountChannel> accountChannels;
+    List<AccountChannel> accountChannels;
 }

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Workspace.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Workspace.java
@@ -53,41 +53,55 @@ public class Workspace{
     @OneToMany(mappedBy = "workspace", orphanRemoval = true)
     @BatchSize(size=5)
     List<AccountWorkspace> accounts;
+
+    @Getter
+    public static class CreateDto{
+        private String workspaceName;
+        private String workspaceDescription;
+        private Long channelCreatorId;
+        private String channelName;
+        private String channelTopic;
+        private String channelDescription;
+
+        public Workspace toWorkspaceEntity(){
+            return Workspace.builder()
+                    .name(workspaceName)
+                    .description(workspaceDescription)
+                    .settings(0)
+                    .status(0)
+                    .createdt(LocalDateTime.now())
+                    .modifydt(LocalDateTime.now())
+                    .build();
+        }
+
+        public Channel toChannelEntity(Workspace workspace, Account account){
+            return Channel.builder()
+                    .workspace(workspace)
+                    .account(account)
+                    .name(channelName)
+                    .topic(channelTopic)
+                    .description(channelDescription)
+                    .settings(0)
+                    .status(0)
+                    .createdt(LocalDateTime.now())
+                    .modifydt(LocalDateTime.now())
+                    .build();
+        }
+    }
     
     @Getter
-    public static class ImportDto{
+    public static class EditDto {
         private String name;
         private String description;
         private Integer settings;
         private Integer status; // TODO: converter 문제 해결 시 String으로
-
-        @QueryProjection
-        public ImportDto(String name, String description, Integer settings, Integer status) {
-            this.name = name;
-            this.description = description;
-            this.settings = settings;
-            this.status = status;
-        }
-
-        public Workspace toEntity(){
-            settings = (settings == null) ? 0 : settings;
-            status = (status == null) ? 0 : status;
-            return Workspace.builder()
-                .name(name)
-                .description(description)
-                .settings(settings)
-                .status(status)
-                .build();
-        }
-    
-        public Workspace changeValues(Workspace workspace){
-            return Workspace.builder()
-                .id(workspace.getId())
-                .name(name)
-                .description(description)
-                .settings(settings)
-                .status(status)
-                .build();
+        
+        public Workspace toEntity(Workspace workspace){
+            workspace.setName(name);
+            workspace.setDescription(description);
+            workspace.setSettings(settings);
+            workspace.setStatus(status);
+            return workspace;
         }
     }
     

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Workspace.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Workspace.java
@@ -56,9 +56,9 @@ public class Workspace{
 
     @Getter
     public static class CreateDto{
+        private Long creatorId;
         private String workspaceName;
         private String workspaceDescription;
-        private Long channelCreatorId;
         private String channelName;
         private String channelTopic;
         private String channelDescription;

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/repository/channel/ChannelRepositoryImpl.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/repository/channel/ChannelRepositoryImpl.java
@@ -3,6 +3,8 @@ package lastpunch.workspace.repository.channel;
 import java.util.List;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -17,6 +19,7 @@ import static lastpunch.workspace.entity.QAccountChannel.accountChannel;
 @Repository
 public class ChannelRepositoryImpl implements ChannelRepositoryCustom{
     private final JPAQueryFactory jpaQueryFactory;
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
     public ChannelRepositoryImpl(EntityManager entityManager){
@@ -27,9 +30,9 @@ public class ChannelRepositoryImpl implements ChannelRepositoryCustom{
     public Page<Account.ExportDto> getMembers(Long id, Pageable pageable) {
         List<Account.ExportDto> results = jpaQueryFactory
                 .select(new QAccount_ExportDto(
-                        account.id, account.email, account.name, account.displayname, account.description,
-                        account.phone, account.country, account.language, account.settings, account.status,
-                        account.createdt, account.modifydt
+                    account.id, account.email, account.name, account.displayname,
+                    account.description, account.phone, account.country, account.language,
+                    account.settings, account.status, account.createdt, account.modifydt
                 ))
                 .from(account)
                 .join(account.channels, accountChannel)
@@ -40,6 +43,8 @@ public class ChannelRepositoryImpl implements ChannelRepositoryCustom{
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
+        
+        logger.info(results.toString());
 
         long count = jpaQueryFactory.select(account)
                 .from(account)

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/repository/workspace/WorkspaceRepositoryImpl.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/repository/workspace/WorkspaceRepositoryImpl.java
@@ -58,9 +58,9 @@ public class WorkspaceRepositoryImpl implements WorkspaceRepositoryCustom{
     public Page<Account.ExportDto> getMembers(Long id, Pageable pageable){
         List<Account.ExportDto> results = jpaQueryFactory
                 .select(new QAccount_ExportDto(
-                        account.id, account.email, account.name, account.displayname, account.description,
-                        account.phone, account.country, account.language, account.settings, account.status,
-                        account.createdt, account.modifydt
+                        account.id, account.email, account.name, account.displayname,
+                        account.description, account.phone, account.country, account.language,
+                        account.settings, account.status, account.createdt, account.modifydt
                 ))
                 .from(account)
                 .join(account.workspaces, accountWorkspace)

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/service/ChannelService.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/service/ChannelService.java
@@ -28,40 +28,20 @@ public class ChannelService{
         return Map.of("members", channelRepository.getMembers(id, pageable));
     }
     
-    public void create(Channel.ImportDto channelImportDto){
-        channelRepository.save(
-                Channel.builder()
-                        .workspace(commonService.getWorkspace(channelImportDto.getWorkspaceId()))
-                        .account(commonService.getAccount(channelImportDto.getCreatorId()))
-                        .name(channelImportDto.getName())
-                        .topic(channelImportDto.getTopic())
-                        .description(channelImportDto.getDescription())
-                        .settings(channelImportDto.getSettings())
-                        .status(channelImportDto.getStatus())
-                        .createdt(LocalDateTime.now())
-                        .modifydt(LocalDateTime.now())
-                        .build()
+    public Map<String, Object> create(Channel.CreateDto createDto){
+        return Map.of(
+            "channel",
+            channelRepository.save(
+                createDto.toEntity(
+                    commonService.getWorkspace(createDto.getWorkspaceId()),
+                    commonService.getAccount(createDto.getCreatorId())
+                )
+            )
         );
     }
     
-    public void edit(Long id, Channel.ImportDto channelImportDto){
-        Channel channel = commonService.getChannel(id);
-        if(channelImportDto.getName() != null){
-            channel.setName(channelImportDto.getName());
-        }
-        if(channelImportDto.getTopic() != null){
-            channel.setTopic(channelImportDto.getTopic());
-        }
-        if(channelImportDto.getDescription() != null){
-            channel.setDescription(channelImportDto.getDescription());
-        }
-        if(channelImportDto.getSettings() != null){
-            channel.setSettings(channelImportDto.getSettings());
-        }
-        if(channelImportDto.getStatus() != null){
-            channel.setStatus(channelImportDto.getStatus());
-        }
-        channelRepository.save(channel);
+    public void edit(Long id, Channel.EditDto editDto){
+        channelRepository.save(editDto.toEntity(commonService.getChannel(id)));
     }
     
     public void delete(Long id){

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/service/ChannelService.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/service/ChannelService.java
@@ -1,22 +1,28 @@
 package lastpunch.workspace.service;
 
 import lastpunch.workspace.entity.Channel;
+import lastpunch.workspace.repository.AccountChannelRepository;
 import lastpunch.workspace.repository.channel.ChannelRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 
 @Service
 public class ChannelService{
     private final ChannelRepository channelRepository;
+    private final AccountChannelRepository accountChannelRepository;
+    
     private final CommonService commonService;
     
     @Autowired
-    public ChannelService(ChannelRepository channelRepository, CommonService commonService){
+    public ChannelService(
+            ChannelRepository channelRepository,
+            AccountChannelRepository accountChannelRepository,
+            CommonService commonService){
         this.channelRepository = channelRepository;
+        this.accountChannelRepository = accountChannelRepository;
         this.commonService = commonService;
     }
     
@@ -29,15 +35,18 @@ public class ChannelService{
     }
     
     public Map<String, Object> create(Channel.CreateDto createDto){
-        return Map.of(
-            "channel",
-            channelRepository.save(
-                createDto.toEntity(
-                    commonService.getWorkspace(createDto.getWorkspaceId()),
-                    commonService.getAccount(createDto.getCreatorId())
-                )
+        Channel newChannel = channelRepository.save(
+            createDto.toEntity(
+                commonService.getWorkspace(createDto.getWorkspaceId()),
+                commonService.getAccount(createDto.getCreatorId())
             )
         );
+    
+        // TODO: creator id를 header에서 가져온다면 코드를 수정
+        // TODO: 권한 관련 부분 수정할 때 하드코딩한 roleId 수정
+        accountChannelRepository.add(createDto.getCreatorId(), newChannel.getId(), 2L);
+        
+        return Map.of("channel", newChannel.export());
     }
     
     public void edit(Long id, Channel.EditDto editDto){


### PR DESCRIPTION
변경 사항
- 워크스페이스를 생성할 때 채널도 하나 함께 생성하도록 수정
- POST /workspace 및 POST /channel API가 이제 생성된 결과값을 반환
- Role의 accountChannels 멤버를 Set -> List로 변경 (지수님 이전 PR 피드백 반영)
- DTO 관련 수정
  - 워크스페이스, 서버의 import DTO를 생성에 필요한 DTO와 수정에 필요한 DTO로 분리

버그 수정
- GET /channel/{id}/members API의 기능 정상화

resolves #91.