### PR TITLE
fix: iOS 앱을 고려하여 CORS 설정 제거

### DIFF
--- a/src/backend/chat/src/main/java/lastpunch/chat/config/ChatConfig.java
+++ b/src/backend/chat/src/main/java/lastpunch/chat/config/ChatConfig.java
@@ -35,7 +35,7 @@ public class ChatConfig implements WebSocketMessageBrokerConfigurer{
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint(ChatConstant.ENDPOINT)
-            .setAllowedOrigins("http://localhost:3000", "http://127.0.0.1:3000")
+            .setAllowedOrigins("*")
             .withSockJS()
             .setSupressCors(true);
     }


### PR DESCRIPTION
다음 출처를 참고, CORS allow origin을 wildcard로 처리

https://stackoverflow.com/questions/42094515/cors-security-with-mobile-apps
https://stackoverflow.com/questions/33986799/what-cors-policy-to-use-for-ios-and-android-apps