### PR TITLE
fix: 채팅 목록을 호출하는 API에서 배열을 뒤집어서 반환

### DIFF
--- a/src/backend/chat/src/main/java/lastpunch/chat/repository/MongoDbRepository.java
+++ b/src/backend/chat/src/main/java/lastpunch/chat/repository/MongoDbRepository.java
@@ -1,12 +1,9 @@
 package lastpunch.chat.repository;
 
 import lastpunch.chat.entity.Message;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MongoDbRepository extends MongoRepository<Message, String>, MongoDbRepositoryCustom{
-    Page<Message> findAllByChannelIdOrderByCreateDtDesc(String channelId, Pageable pageable);
 }

--- a/src/backend/chat/src/main/java/lastpunch/chat/repository/MongoDbRepositoryCustom.java
+++ b/src/backend/chat/src/main/java/lastpunch/chat/repository/MongoDbRepositoryCustom.java
@@ -6,5 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MongoDbRepositoryCustom{
+    Page<Message> findRecentMessages(String channelId, Pageable pageable);
     Page<Message> findOldMessages(String channelId, LocalDateTime dateTime, Pageable pageable);
 }

--- a/src/backend/chat/src/main/java/lastpunch/chat/repository/MongoDbRepositoryImpl.java
+++ b/src/backend/chat/src/main/java/lastpunch/chat/repository/MongoDbRepositoryImpl.java
@@ -1,6 +1,8 @@
 package lastpunch.chat.repository;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import lastpunch.chat.entity.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,14 +29,31 @@ public class MongoDbRepositoryImpl implements MongoDbRepositoryCustom{
     }
     
     @Override
+    public Page<Message> findRecentMessages(String channelId, Pageable pageable){
+        Query query = new Query()
+            .addCriteria(Criteria.where("channelId").is(channelId))
+            .with(Sort.by(Direction.DESC, "createDt"))
+            .with(pageable);
+    
+        return getReversedPages(query, pageable);
+    }
+    
+    @Override
     public Page<Message> findOldMessages(String channelId, LocalDateTime dateTime, Pageable pageable){
         Query query = new Query()
             .addCriteria(Criteria.where("channelId").is(channelId))
             .addCriteria(Criteria.where("createDt").lt(dateTime))
             .with(Sort.by(Direction.DESC, "createDt"))
             .with(pageable);
+        
+        return getReversedPages(query, pageable);
+    }
+    
+    private Page<Message> getReversedPages(Query query, Pageable pageable){
+        List<Message> messageList = mongoTemplate.find(query, Message.class);
+        Collections.reverse(messageList);
         return new PageImpl<>(
-            mongoTemplate.find(query, Message.class),
+            messageList,
             pageable,
             mongoTemplate.count(query, Message.class)
         );

--- a/src/backend/chat/src/main/java/lastpunch/chat/service/MongoDbService.java
+++ b/src/backend/chat/src/main/java/lastpunch/chat/service/MongoDbService.java
@@ -21,9 +21,7 @@ public class MongoDbService{
     }
     
     public Page<Message> getRecentMessages(String channelId){
-        return mongoDbRepository.findAllByChannelIdOrderByCreateDtDesc(
-            channelId, PageRequest.of(page, size)
-        );
+        return mongoDbRepository.findRecentMessages(channelId, PageRequest.of(page, size));
     }
     
     public Page<Message> getOldMessages(GetOlderDto getOlderDto){


### PR DESCRIPTION
- 채팅 서버의 `POST /chat/recent`와 `POST /chat/old` API에서 배열을 기존 내림차순에서 오름차순으로 뒤집어서 반환하도록 변경

Docker container 업데이트 했습니다. AWS 환경에 접속해서 동작 확인 후 merge 해주세요!