### PR TITLE
chore: 테스트 데이터 sql 스크립트에 채널 소유자 정보 수정

### DIFF
--- a/scripts/MySQL/workspace_test.sql
+++ b/scripts/MySQL/workspace_test.sql
@@ -14,6 +14,7 @@ INSERT INTO account (email, password, name, country, language, settings, status,
     VALUES ('qwer@qwer', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Batman', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
     VALUES ('zxcv@zxcv', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Spider-man', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
+
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
     VALUES ('1111@asdf', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Captain America', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
@@ -22,6 +23,7 @@ INSERT INTO account (email, password, name, country, language, settings, status,
     VALUES ('3333@asdf', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Wonder Woman', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
     VALUES ('4444@asdf', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Deadpool', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
+
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
     VALUES ('5555@asdf', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Antman', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
@@ -31,8 +33,9 @@ INSERT INTO account (email, password, name, country, language, settings, status,
 INSERT INTO account (id, email, password, name, country, language, settings, status, createDt, modifyDt)
     VALUES (123456789123456, 'test@test', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Big Integer Man', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
 
+
 INSERT INTO workspace(name, settings, createDt, modifyDt)
-    VALUES ('ws1', 0, '1234-01-01', '9999-12-31');
+    VALUES ('Heroes', 0, '1234-01-01', '9999-12-31');
 INSERT INTO workspace(name, settings, createDt, modifyDt)
     VALUES ('ws2', 0, '1234-01-01', '9999-12-31');
 INSERT INTO workspace(name, settings, createDt, modifyDt)
@@ -51,11 +54,11 @@ INSERT INTO role (name) VALUES ('owner');
 
 
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (1, 'channel1', 'topic1', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
+    VALUES (1, 'All Heroes', 'topic1', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (1, 'channel2', 'topic2', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
+    VALUES (1, 'Marvel Heroes', 'topic2', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (1, 'channel3', 'topic3', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
+    VALUES (1, 'DC Heroes', 'topic3', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
     VALUES (1, 'channel4', 'topic4', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
@@ -64,56 +67,73 @@ INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, 
     VALUES (1, 'channel6', 'topic6', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
 
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (2, 'channel7', 'topic7', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
+    VALUES (2, 'ws2-default-channel', 'topic7', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (3, 'channel8', 'topic8', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
+    VALUES (3, 'ws3-default-channel', 'topic8', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (4, 'channel9', 'topic9', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
+    VALUES (4, 'ws4-default-channel', 'topic9', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (5, 'channel10', 'topic10', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
+    VALUES (5, 'ws5-default-channel', 'topic10', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (6, 'channel11', 'topic11', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
-
-INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (2, 'channel12', 'topic12', 'channels', 1, '1234-01-01', '9999-12-31');
-INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (2, 'channel13', 'topic13', 'channels', 1, '1234-01-01', '9999-12-31');
+    VALUES (6, 'ws6-default-channel', 'topic11', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
 
 
 INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 1, 3);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 2, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 3, 2);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 4, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 5, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 6, 2);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 2, 3);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 3, 3);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 4, 3);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 5, 3);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 6, 3);
 
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (2, 1, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (2, 2, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (2, 3, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (2, 1, 2);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 1, 2);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (4, 1, 2);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (5, 1, 2);
 
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 1, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 2, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 3, 3);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 4, 2);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 5, 2);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (6, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (7, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (8, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (9, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (10, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (11, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (12, 1, 1);
 
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (4, 1, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (5, 1, 1);
 
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 1, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (2, 2, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (3, 3, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (4, 4, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (5, 5, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (6, 6, 3);
+
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 7, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 8, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 9, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 10, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 11, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 12, 3);
 
 INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 1, 2);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (2, 1, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (3, 1, 3);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (4, 1, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (5, 1, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (6, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (2, 1, 2);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (3, 1, 2);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (4, 1, 2);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (5, 1, 2);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (6, 1, 2);
 
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 2, 3);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 3, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 4, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 5 ,2);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 6, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (7, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (8, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (9, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (10, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (11, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (12, 1, 1);
 
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (3, 3, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (6, 5, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (9, 7, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (4, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (5, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (6, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (8, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (9, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (10, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (11, 2, 1);
+
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (2, 3, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (7, 3, 1);

--- a/src/backend/docker-setup/mysql/initdb.d/Insert.sql
+++ b/src/backend/docker-setup/mysql/initdb.d/Insert.sql
@@ -14,6 +14,7 @@ INSERT INTO account (email, password, name, country, language, settings, status,
     VALUES ('qwer@qwer', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Batman', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
     VALUES ('zxcv@zxcv', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Spider-man', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
+
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
     VALUES ('1111@asdf', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Captain America', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
@@ -22,6 +23,7 @@ INSERT INTO account (email, password, name, country, language, settings, status,
     VALUES ('3333@asdf', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Wonder Woman', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
     VALUES ('4444@asdf', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Deadpool', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
+
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
     VALUES ('5555@asdf', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Antman', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
 INSERT INTO account (email, password, name, country, language, settings, status, createDt, modifyDt)
@@ -31,8 +33,9 @@ INSERT INTO account (email, password, name, country, language, settings, status,
 INSERT INTO account (id, email, password, name, country, language, settings, status, createDt, modifyDt)
     VALUES (123456789123456, 'test@test', '$2a$10$BkGjbK/UK9NiwgWEvYdRoedRDPhP1Nhh/ttog4eI8eBdvq3CCXhJC', 'Big Integer Man', 'kor', 'eng', 1, 2, '1234-01-01', '9999-12-31');
 
+
 INSERT INTO workspace(name, settings, createDt, modifyDt)
-    VALUES ('ws1', 0, '1234-01-01', '9999-12-31');
+    VALUES ('Heroes', 0, '1234-01-01', '9999-12-31');
 INSERT INTO workspace(name, settings, createDt, modifyDt)
     VALUES ('ws2', 0, '1234-01-01', '9999-12-31');
 INSERT INTO workspace(name, settings, createDt, modifyDt)
@@ -51,11 +54,11 @@ INSERT INTO role (name) VALUES ('owner');
 
 
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (1, 'channel1', 'topic1', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
+    VALUES (1, 'All Heroes', 'topic1', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (1, 'channel2', 'topic2', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
+    VALUES (1, 'Marvel Heroes', 'topic2', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (1, 'channel3', 'topic3', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
+    VALUES (1, 'DC Heroes', 'topic3', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
     VALUES (1, 'channel4', 'topic4', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
@@ -64,56 +67,73 @@ INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, 
     VALUES (1, 'channel6', 'topic6', 'pagination test for channels in workspace', 1, '1234-01-01', '9999-12-31');
 
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (2, 'channel7', 'topic7', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
+    VALUES (2, 'ws2-default-channel', 'topic7', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (3, 'channel8', 'topic8', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
+    VALUES (3, 'ws3-default-channel', 'topic8', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (4, 'channel9', 'topic9', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
+    VALUES (4, 'ws4-default-channel', 'topic9', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (5, 'channel10', 'topic10', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
+    VALUES (5, 'ws5-default-channel', 'topic10', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
 INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (6, 'channel11', 'topic11', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
-
-INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (2, 'channel12', 'topic12', 'channels', 1, '1234-01-01', '9999-12-31');
-INSERT INTO channel (workspaceId, name, topic, description, settings, createDt, modifyDt)
-    VALUES (2, 'channel13', 'topic13', 'channels', 1, '1234-01-01', '9999-12-31');
+    VALUES (6, 'ws6-default-channel', 'topic11', 'pagination test for channels of one member', 1, '1234-01-01', '9999-12-31');
 
 
 INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 1, 3);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 2, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 3, 2);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 4, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 5, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 6, 2);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 2, 3);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 3, 3);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 4, 3);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 5, 3);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (1, 6, 3);
 
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (2, 1, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (2, 2, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (2, 3, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (2, 1, 2);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 1, 2);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (4, 1, 2);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (5, 1, 2);
 
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 1, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 2, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 3, 3);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 4, 2);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (3, 5, 2);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (6, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (7, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (8, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (9, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (10, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (11, 1, 1);
+INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (12, 1, 1);
 
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (4, 1, 1);
-INSERT INTO accountworkspace (accountId, workspaceId, roleId) VALUES (5, 1, 1);
 
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 1, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (2, 2, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (3, 3, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (4, 4, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (5, 5, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (6, 6, 3);
+
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 7, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 8, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 9, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 10, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 11, 3);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 12, 3);
 
 INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 1, 2);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (2, 1, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (3, 1, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (4, 1, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (5, 1, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (6, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (2, 1, 2);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (3, 1, 2);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (4, 1, 2);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (5, 1, 2);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (6, 1, 2);
 
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 2, 2);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 3, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 4, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 5 ,2);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (1, 6, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (7, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (8, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (9, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (10, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (11, 1, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (12, 1, 1);
 
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (3, 3, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (6, 5, 1);
-INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (9, 7, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (4, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (5, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (6, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (8, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (9, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (10, 2, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (11, 2, 1);
+
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (2, 3, 1);
+INSERT INTO accountchannel (accountId, channelId, roleId) VALUES (7, 3, 1);


### PR DESCRIPTION
- #264 로 인해 채널 소유자 정보가 제대로 지정되지 않은 경우 채널 1개 정보 요청 API를 호출했을 때 BusinessException이 발생합니다.
- 워크스페이스 멤버 및 채널 멤버 관련 SQL insert 구문을 전면적으로 수정
- 일부 채널 name을 수정