### PR TITLE
계정 정보 수정 API 추가

### DIFF
--- a/docs/API_references/WorkspaceServer.postman_collection.json
+++ b/docs/API_references/WorkspaceServer.postman_collection.json
@@ -316,6 +316,303 @@
 							"body": "{\n    \"data\": {\n        \"account\": {\n            \"id\": 1,\n            \"email\": \"1\",\n            \"name\": \"Saitama\",\n            \"description\": null,\n            \"phone\": null,\n            \"country\": \"kor\",\n            \"imageNum\": null,\n            \"createDt\": \"1234-01-01 24:00:00\",\n            \"modifyDt\": \"9999-12-31 24:00:00\"\n        }\n    },\n    \"code\": \"12000\"\n}"
 						}
 					]
+				},
+				{
+					"name": "edit account",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "X-AUTH-TOKEN",
+								"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxd2VyQHF3ZXIiLCJhdXRoIjoiUk9MRV9BRE1JTiIsInVzZXJJZCI6MywiZXhwIjoxNjQ0MjA4NDMyfQ.UDNrnkMt4N7Cq1ikfw7AdyzzAYUUV3SK01SCxXQHoyOTFqAgPbFs6i5cHIPxH2Ohw6D5tBysqIeJDnIsWRLe2Q",
+								"type": "text"
+							},
+							{
+								"key": "userid",
+								"value": "1",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"name\": \"One Punch Man\",\r\n    \"description\": \"edit account information\",\r\n    \"phone\": \"010-8765-4321\",\r\n    \"country\": \"Japan\",\r\n    \"imageNum\": 11\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8080/account/1",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"account",
+								"1"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "Success - 12000",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "X-AUTH-TOKEN",
+										"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxd2VyQHF3ZXIiLCJhdXRoIjoiUk9MRV9BRE1JTiIsInVzZXJJZCI6MywiZXhwIjoxNjQ0MjA4NDMyfQ.UDNrnkMt4N7Cq1ikfw7AdyzzAYUUV3SK01SCxXQHoyOTFqAgPbFs6i5cHIPxH2Ohw6D5tBysqIeJDnIsWRLe2Q",
+										"type": "text"
+									},
+									{
+										"key": "userid",
+										"value": "1",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"One Punch Man\",\r\n    \"description\": \"edit account information\",\r\n    \"phone\": \"010-8765-4321\",\r\n    \"country\": \"Japan\",\r\n    \"imageNum\": 11\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/account/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"account",
+										"1"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Date",
+									"value": "Sat, 19 Feb 2022 11:15:09 GMT"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=60"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [
+								{
+									"expires": "Invalid Date"
+								}
+							],
+							"body": "{\n    \"data\": {},\n    \"code\": \"12000\"\n}"
+						},
+						{
+							"name": "Fail - 12002 ACCOUNT_NOT_EXIST",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "X-AUTH-TOKEN",
+										"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxd2VyQHF3ZXIiLCJhdXRoIjoiUk9MRV9BRE1JTiIsInVzZXJJZCI6MywiZXhwIjoxNjQ0MjA4NDMyfQ.UDNrnkMt4N7Cq1ikfw7AdyzzAYUUV3SK01SCxXQHoyOTFqAgPbFs6i5cHIPxH2Ohw6D5tBysqIeJDnIsWRLe2Q",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"One Punch Man\",\r\n    \"description\": \"edit account information\",\r\n    \"phone\": \"010-8765-4321\",\r\n    \"country\": \"Japan\",\r\n    \"imageNum\": 11\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8082/account/123",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8082",
+									"path": [
+										"account",
+										"123"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Date",
+									"value": "Sat, 19 Feb 2022 11:17:04 GMT"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=60"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [
+								{
+									"expires": "Invalid Date"
+								}
+							],
+							"body": "{\n    \"err\": {\n        \"desc\": \"Snack 사용자가 아닙니다\",\n        \"msg\": \"ACCOUNT_NOT_EXIST\"\n    },\n    \"code\": \"12002\"\n}"
+						},
+						{
+							"name": "Fail - 12008 INVALID_USERID",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"One Punch Man\",\r\n    \"description\": \"edit account information\",\r\n    \"phone\": \"010-8765-4321\",\r\n    \"country\": \"Japan\",\r\n    \"imageNum\": 11\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/account/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"account",
+										"1"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Date",
+									"value": "Sat, 19 Feb 2022 11:14:25 GMT"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=60"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"err\": {\n        \"desc\": \"사용자 ID가 정상적으로 제공되지 않았습니다\",\n        \"msg\": \"INVALID_USERID\"\n    },\n    \"code\": \"12008\"\n}"
+						},
+						{
+							"name": "Fail - 12011 PERMISSION_DENIED",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "X-AUTH-TOKEN",
+										"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJxd2VyQHF3ZXIiLCJhdXRoIjoiUk9MRV9BRE1JTiIsInVzZXJJZCI6MywiZXhwIjoxNjQ0MjA4NDMyfQ.UDNrnkMt4N7Cq1ikfw7AdyzzAYUUV3SK01SCxXQHoyOTFqAgPbFs6i5cHIPxH2Ohw6D5tBysqIeJDnIsWRLe2Q",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"One Punch Man\",\r\n    \"description\": \"edit account information\",\r\n    \"phone\": \"010-8765-4321\",\r\n    \"country\": \"Japan\",\r\n    \"imageNum\": 11\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/account/3",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"account",
+										"3"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Date",
+									"value": "Sat, 19 Feb 2022 11:16:18 GMT"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=60"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [
+								{
+									"expires": "Invalid Date"
+								}
+							],
+							"body": "{\n    \"err\": {\n        \"desc\": \"해당 작업을 실행할 권한이 없습니다\",\n        \"msg\": \"PERMISSION_DENIED\"\n    },\n    \"code\": \"12011\"\n}"
+						}
+					]
 				}
 			]
 		},
@@ -2975,7 +3272,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"data\": {},\n    \"code\": \"12000\"\n}"
+							"body": "{\n    \"code\": \"12000\"\n}"
 						},
 						{
 							"name": "Fail - 12003 CHANNEL_NOT_EXIST",
@@ -3036,10 +3333,10 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"err\": {\n        \"desc\": \"존재하지 않는 채널입니다\",\n        \"msg\": \"CHANNEL_NOT_EXIST\"\n    },\n    \"code\": \"12003\"\n}"
+							"body": "{\n    \"code\": \"12003\",\n    \"err\": {\n        \"msg\": \"CHANNEL_NOT_EXIST\",\n        \"desc\": \"존재하지 않는 채널입니다.\"\n    }\n}"
 						},
 						{
-							"name": "Fail - 12011 PERMISSION_DENIED",
+							"name": "delete channel",
 							"originalRequest": {
 								"method": "DELETE",
 								"header": [
@@ -3064,12 +3361,12 @@
 									}
 								},
 								"url": {
-									"raw": "http://localhost:8080/channel/23",
+									"raw": "http://localhost:8082/channel/23",
 									"protocol": "http",
 									"host": [
 										"localhost"
 									],
-									"port": "8080",
+									"port": "8082",
 									"path": [
 										"channel",
 										"23"

--- a/docs/API_references/workspace_apis.md
+++ b/docs/API_references/workspace_apis.md
@@ -10,15 +10,15 @@
 | GET    | /workspace/{id}/channels        | 워크스페이스 1개의 채널 전체 조회       | -                  | 채널 목록              | 현재 요청한 사용자가 소속된 채널만 조회 |
 | GET    | /workspace/{id}/channels/paging | 워크스페이스 1개의 채널 조회 (paging) | -                  | 채널 목록              | paging                 |
 | POST   | /workspace                      | 워크스페이스 생성                 | WorkspaceCreateDTO | 워크스페이스, 채널 각 1개 정보 | -                      |
-| PUT    | /workspace/{id}                 | 워크스페이스 수정                 | WorkspaceEditDTO   | -                  | -                      |
-| DELETE | /workspace/{id}                 | 워크스페이스 삭제                 | -                  | -                  | -                      |
+| PUT    | /workspace/{id}                 | 워크스페이스 수정                 | WorkspaceEditDTO   | -                  | 권한 관련 하단 참조            |
+| DELETE | /workspace/{id}                 | 워크스페이스 삭제                 | -                  | -                  | 권한 관련 하단 참조            |
 
 ## 워크스페이스-멤버 API
-| Method | URI               | Description      | Request Body        | Response Body | etc                                   |
-|--------|-------------------|------------------|---------------------|---------------|---------------------------------------|
-| POST   | /workspace/member | 워크스페이스에 멤버 추가    | AccountWorkspaceDTO | -             | -                                     |
-| PUT    | /workspace/member | 워크스페이스에 멤버 정보 수정 | AccountWorkspaceDTO | -             | -                                     |
-| DELETE | /workspace/member | 워크스페이스에서 멤버 삭제   | -                   | -             | URL parameter: accountId, workspaceId |
+| Method | URI               | Description      | Request Body        | Response Body | etc                                                  |
+|--------|-------------------|------------------|---------------------|---------------|------------------------------------------------------|
+| POST   | /workspace/member | 워크스페이스에 멤버 추가    | AccountWorkspaceDTO | -             | 권한 관련 하단 참조                                          |
+| PUT    | /workspace/member | 워크스페이스에 멤버 정보 수정 | AccountWorkspaceDTO | -             | 권한 관련 하단 참조                                          |
+| DELETE | /workspace/member | 워크스페이스에서 멤버 삭제   | -                   | -             | URL parameter: (accountId, workspaceId), 권한 관련 하단 참조 |
 
 ## 채널 API
 | Method | URI                   | Description              | Request Body     | Response Body | etc          |
@@ -26,23 +26,24 @@
 | GET    | /channel/{id}         | 채널 1개의 정보 조회             | -                | 채널 1개 정보      | 채널 소유자 정보 포함 |
 | GET    | /channel/{id}/members | 채널 1개의 멤버 조회             | -                | 멤버 목록         | paging       |
 | POST   | /channel              | 채널 생성                    | ChannelCreateDTO | 채널 1개 정보      | -            |
-| PUT    | /channel/{id}         | 채널 수정                    | ChannelEditDTO   | -             | -            |
-| DELETE | /channel/{id}         | 채널 삭제                    | -                | -             | -            |
+| PUT    | /channel/{id}         | 채널 수정                    | ChannelEditDTO   | -             | 권한 관련 하단 참조  |
+| DELETE | /channel/{id}         | 채널 삭제                    | -                | -             | 권한 관련 하단 참조  |
 | POST   | /channel/find         | 채널 이름으로 현재 워크스페이스의 채널 검색 | ChannelFindDTO   | 채널 목록         | paging       |
 
 
 ## 채널-멤버 API
-| Method | URI             | Description     | Request Body      | Response Body | etc                                 |
-|--------|-----------------|-----------------|-------------------|---------------|-------------------------------------|
-| POST   | /channel/member | 채널에 멤버 추가       | AccountChannelDto | -             | -                                   |
-| PUT    | /channel/member | 채널에 대한 멤버 정보 수정 | AccountChannelDto | -             | -                                   |
-| DELETE | /channel/member | 채널에서 멤버 삭제      | -                 | -             | URL parameter: accountId, channelId |
+| Method | URI             | Description     | Request Body      | Response Body | etc                                                |
+|--------|-----------------|-----------------|-------------------|---------------|----------------------------------------------------|
+| POST   | /channel/member | 채널에 멤버 추가       | AccountChannelDto | -             | 권한 관련 하단 참조                                        |
+| PUT    | /channel/member | 채널에 대한 멤버 정보 수정 | AccountChannelDto | -             | 권한 관련 하단 참조                                        |
+| DELETE | /channel/member | 채널에서 멤버 삭제      | -                 | -             | URL parameter: (accountId, channelId), 권한 관련 하단 참조 |
 
 ## 계정 API
-| Method | URI           | Description      | Request Body   | Response Body | etc    |
-|--------|---------------|------------------|----------------|---------------|--------|
-| POST   | /account/find | 이메일로 계정 목록 조회    | AccountFindDto | 계정 목록         | paging |
-| GET    | /account/self | 현재 접속한 사용자 정보 조회 | -              | 계정 1개 정보      | -      |
+| Method | URI           | Description      | Request Body   | Response Body | etc                        |
+|--------|---------------|------------------|----------------|---------------|----------------------------|
+| POST   | /account/find | 이메일로 계정 목록 조회    | AccountFindDto | 계정 목록         | paging                     |
+| GET    | /account/self | 현재 접속한 사용자 정보 조회 | -              | 계정 1개 정보      | -                          |
+| PUT    | /account/{id} | 사용자 정보 수정        | -              | -             | 요청자 id와 대상 id가 일치하지 않으면 거부 |
 
 
 - WorkspaceCreateDTO 예시
@@ -139,10 +140,12 @@
   - 더 자세한 내용은 Spring Boot Pageable 객체 참조
 
 ## 워크스페이스 / 채널 권한 시나리오
-- 워크스페이스 / 채널 멤버 테이블에서 권한은 현재 `normal_user`, `admin`, `owner`로 나뉨
+- 워크스페이스/채널 멤버 테이블에서 권한은 현재 `normal_user`, `admin`, `owner`로 나뉨
+- 워크스페이스/채널의 정보는 해당 워크스페이스/채널의 `admin` 혹은 `owner`만 수정할 수 있음
+- 워크스페이스/채널은 해당 채널의 `owner`만 삭제할 수 있음
 - 요청자가 해당 워크스페이스/채널의 멤버가 아니면 새로운 멤버를 초대할 수 없음
 - 어떤 워크스페이스/채널에 새로운 멤버가 초대되었을 때, 해당 멤버의 권한은 `normal_user`
-- 워크스페이스 / 채널 멤버 수정 API (권한 수정)는 현재 세션의 요청자의 권한에 따라 허용 또는 거부
+- 워크스페이스/채널 멤버 수정 API (권한 수정)는 현재 세션의 요청자의 권한에 따라 허용 또는 거부
   - 요청자의 권한이 `normal_user`일 때 API 요청 거부
   - 요청자의 권한이 `admin`인 경우 대상자가 본인이면 `owner`로 변경하려고 하는 경우 거부, 이외 권한으로 변경은 허용
   - 요청자의 권한이 `admin`일 떄 대상자가 본인이 아니면 `normal_user`를 `admin`으로 변경하는 경우만 허용

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/controller/AccountController.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/controller/AccountController.java
@@ -10,7 +10,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,6 +42,16 @@ public class AccountController{
             accountService.getByEmail(
                 accountFindDto.getEmail(), pageable, Parser.getHeaderId(header)
             )
+        );
+    }
+    
+    @PutMapping
+    public ResponseEntity<Object> edit(
+            @RequestBody Account.EditDto editDto,
+            @PathVariable("id") Long id,
+            @RequestHeader Map<String, Object> header){
+        return Response.ok(
+            accountService.edit(editDto, id, Parser.getHeaderId(header))
         );
     }
 }

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/controller/AccountController.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/controller/AccountController.java
@@ -45,7 +45,7 @@ public class AccountController{
         );
     }
     
-    @PutMapping
+    @PutMapping("/{id}")
     public ResponseEntity<Object> edit(
             @RequestBody Account.EditDto editDto,
             @PathVariable("id") Long id,

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Account.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Account.java
@@ -77,6 +77,38 @@ public class Account{
     }
     
     @Getter
+    public static class EditDto{
+        private String name;
+        private String description;
+        private String phone;
+        private String country;
+        private Integer imageNum;
+        
+        public Account toEntity(Account account){
+            if(name != null){
+                account.setName(name);
+            }
+            if(description != null){
+                account.setDescription(description);
+            }
+            if(phone != null){
+                account.setPhone(phone);
+            }
+            if(country != null){
+                account.setCountry(country);
+            }
+            if(imageNum != null){
+                account.setImagenum(imageNum);
+            }
+            if((name != null) || (description != null) || (phone != null)
+                || (country != null) || (imageNum != null)){
+                account.setModifydt(LocalDateTime.now());
+            }
+            return account;
+        }
+    }
+    
+    @Getter
     @Builder
     public static class ExportDto{
         private Long id;

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Workspace.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/entity/Workspace.java
@@ -95,7 +95,7 @@ public class Workspace{
             if(imageNum != null){
                 workspace.setImagenum(imageNum);
             }
-            if(name != null || description != null || imageNum != null){
+            if((name != null) || (description != null) || (imageNum != null)){
                 workspace.setModifydt(LocalDateTime.now());
             }
             return workspace;

--- a/src/backend/workspace/src/main/java/lastpunch/workspace/service/AccountService.java
+++ b/src/backend/workspace/src/main/java/lastpunch/workspace/service/AccountService.java
@@ -1,9 +1,12 @@
 package lastpunch.workspace.service;
 
+import java.util.HashMap;
 import java.util.Map;
 
+import java.util.Objects;
 import lastpunch.workspace.common.StatusCode;
 import lastpunch.workspace.common.exception.BusinessException;
+import lastpunch.workspace.entity.Account;
 import lastpunch.workspace.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -34,5 +37,15 @@ public class AccountService{
         return Map.of(
             "accounts", accountRepository.findByEmail(email, pageable, id)
         );
+    }
+    
+    
+    public Map<String, Object> edit(Account.EditDto editDto, Long targetId, Long requesterId){
+        // 본인 외에는 개인정보를 수정할 수 없음
+        if(!Objects.equals(targetId, requesterId)){
+            throw new BusinessException(StatusCode.PERMISSION_DENIED);
+        }
+        accountRepository.save(editDto.toEntity(commonService.getAccount(targetId)));
+        return new HashMap<>(); // 비어 있는 map: FE에 일관적인 포맷의 response 전달
     }
 }


### PR DESCRIPTION
- `PUT /account/{id}` 추가: `Account` 엔티티에서 `name`, `description`, `phone`, `country`, `imageNum`를 수정할 수 있는 API
- 관련 문서 업데이트